### PR TITLE
56-fix-module-discovery

### DIFF
--- a/src/OpenStudioLandscapes/engine/config/__init__.py
+++ b/src/OpenStudioLandscapes/engine/config/__init__.py
@@ -2,6 +2,6 @@ import pathlib
 from importlib import metadata
 from importlib.metadata import Distribution
 
-pkg: str = pathlib.Path(__file__).parent.parent.parent.parent.parent.name
+pkg: str = pathlib.Path(__file__).parent.parent.parent.name
 
 dist: Distribution = metadata.distribution(pkg)

--- a/src/OpenStudioLandscapes/engine/discovery/discovery.py
+++ b/src/OpenStudioLandscapes/engine/discovery/discovery.py
@@ -134,7 +134,8 @@ def get_namespace_packages(where=pathlib.Path.cwd() / ".features") -> List[str]:
     LOGGER.info(
         "Getting installed OpenStudioLandscapes namespace packages from '%s'...", where
     )
-    namespace_packages = find_namespace_packages(
+
+    namespace_packages_ = find_namespace_packages(
         where=where,
         include=["*src.OpenStudioLandscapes.*"],
         exclude=[
@@ -142,8 +143,15 @@ def get_namespace_packages(where=pathlib.Path.cwd() / ".features") -> List[str]:
             "*.doc",  # exclude src.OpenStudioLandscapes.<Feature>.doc from module discovery
         ],
     )
-    LOGGER.info(f"{namespace_packages = }")
+    LOGGER.info(f"{namespace_packages_ = }")
     # ['OpenStudioLandscapes-NukeRLM-8.src.OpenStudioLandscapes.NukeRLM_8', ...]
+
+    # Just take the final part of the namespace package ('NukeRLM_8') an
+    # prepend 'OpenStudioLandscapes'
+    namespace_packages = [f"OpenStudioLandscapes.{i.split('.')[-1]}" for i in namespace_packages_]
+
+    LOGGER.info(f"{namespace_packages = }")
+    # ['OpenStudioLandscapes.NukeRLM_8', ...]
     return namespace_packages
 
 
@@ -284,7 +292,7 @@ def get_config_dict_feature(
     package: str,
     feature: OpenStudioLandscapesDiscoveredFeature,
 ) -> Dict:
-    distribution: Distribution = metadata.distribution(package.partition(".")[0])
+    distribution: Distribution = metadata.distribution(package)
 
     # Create the `config.yml` for the feature
     # with the default `CONFIG_STR` if


### PR DESCRIPTION
Implements [https://github.com/michimussato/OpenStudioLandscapes/issues/56](https://github.com/michimussato/OpenStudioLandscapes/issues/56)

---

Current Work in Progress:

| PR Created | Link |
| ---------- | ---- |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-Ayon/pull/16 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-Dagster/pull/16 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-Deadline-10-2/pull/16 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-Deadline-10-2-Worker/pull/16 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-filebrowser/pull/16 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-Flamenco/pull/8 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-Flamenco-Worker/pull/8 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-Grafana/pull/17 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-Kitsu/pull/16 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-LikeC4/pull/16 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-NukeRLM-8/pull/16 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-OpenCue/pull/16 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-OpenCue-Worker/pull/1 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-RustDeskServer/pull/13 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-SESI-gcc-9-3-Houdini-20/pull/16 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-Syncthing/pull/16 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-Template/pull/16 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-Twingate/pull/12 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-VERT/pull/10 |
| &#x2611; | https://github.com/michimussato/OpenStudioLandscapes-Watchtower/pull/16 |
